### PR TITLE
fix(setup-js): fix action for when working-directory is specified

### DIFF
--- a/.github/workflows/setup-js-test.yml
+++ b/.github/workflows/setup-js-test.yml
@@ -58,3 +58,20 @@ jobs:
         id: setup
         with:
           package-manager: ${{ matrix.package-manager }}
+
+  test-subdirectory:
+    if: ${{ github.event.pull_request.draft == false }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create example package.json and lockfile
+        run: |
+          mkdir app
+          cp ./.artifacts/package-json ./app/package.json
+          cp ./.artifacts/package-lock ./app/package-lock.json
+
+      - name: Setup and install
+        uses: ./setup-js
+        with:
+          working-directory: app

--- a/.github/workflows/setup-js-test.yml
+++ b/.github/workflows/setup-js-test.yml
@@ -60,6 +60,7 @@ jobs:
           package-manager: ${{ matrix.package-manager }}
 
   test-subdirectory:
+    runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout

--- a/setup-js/get-meta.js
+++ b/setup-js/get-meta.js
@@ -2,16 +2,33 @@ const crypto = require('crypto');
 const fs = require('fs');
 
 /**
+ *
+ * @typedef {{
+ *  'cache-prefix'?: string;
+ *  'hash-strategy'?: string;
+ *  'install-args'?: string;
+ *  'install-command'?: string;
+ *  'node-version'?: string;
+ *  'package-manager'?: string;
+ *  'working-directory'?: string;
+ * }} Inputs
+ *
  * @typedef {{
  *  core: import('@actions/core'),
  *  github: import('@actions/github'),
- *  inputs: Record<string, string>,
+ *  inputs: Inputs,
  *  runsOn: string,
  * }} RootContext */
 
 module.exports = function run(
   /** @type {RootContext} */
   { core, github, inputs, runsOn }) {
+  const workingDirectory = inputs['working-directory']
+
+  if (typeof workingDirectory === 'string') {
+    process.chdir(workingDirectory)
+  }
+
   if (!fs.existsSync('package.json')) {
     core.setFailed('No package.json found in current directory');
     return


### PR DESCRIPTION
Despite setting `working-directory` input the action run in the root directory instead of specified directory.