### PR TITLE
fix(setup-js): remove deprecated set-output

### DIFF
--- a/setup-js/action.yml
+++ b/setup-js/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Get global cache directory
       shell: bash
       id: global-cache-dir
-      run: echo "::set-output name=dir::$(${{ steps.metadata.outputs.get-cache-dir-command }})"
+      run: echo "dir=$(${{ steps.metadata.outputs.get-cache-dir-command }})" >> $GITHUB_OUTPUT
 
     - name: Restore node_modules cache
       if: ${{ inputs.cache }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/