### PR TITLE
fix(setup-js): do not cache local node modules

### DIFF
--- a/setup-js/action.yml
+++ b/setup-js/action.yml
@@ -87,9 +87,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@v3
       with:
-        path: |
-          ${{ steps.global-cache-dir.outputs.dir }}
-          ${{ inputs.working-directory }}/node_modules
+        path: ${{ steps.global-cache-dir.outputs.dir }}
         key: ${{ steps.metadata.outputs.node-modules-cache-prefix }}-${{ steps.metadata.outputs.node-modules-cache-suffix }}
         restore-keys: |
           ${{ steps.metadata.outputs.node-modules-cache-prefix }}


### PR DESCRIPTION
From what community says we should not cache local node_modules. I also experienced some weird behaviours on CI regarding missing packages even they have been installed and there is high chance this it because of caching local node_modules.